### PR TITLE
fix: correct privacy page link to use lang prefix

### DIFF
--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -39,7 +39,7 @@ const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID
         <p class="text-xs text-secondary/50 leading-relaxed">
           {t("cookie.banner.accept")}
           <a
-            href="/privacidad"
+            href={`/${lang}/privacidad`}
             target="_blank"
             rel="noopener noreferrer"
             class="text-yellow hover:underline"
@@ -95,7 +95,7 @@ const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID
     consent = localStorage.getItem("cookiesAccepted")
   } catch {}
 
-  const isPrivacyPage = window.location.pathname === "/privacidad"
+  const isPrivacyPage = window.location.pathname.endsWith("/privacidad")
 
   if (consent === "true") {
     loadClarity()


### PR DESCRIPTION
The privacy policy link in the cookie banner was pointing to `/privacidad`
instead of `/${lang}/privacidad`, causing a 404 and showing the banner
on the privacy page itself.